### PR TITLE
LIT fields for Riff Learning

### DIFF
--- a/lti_consumer/lti.py
+++ b/lti_consumer/lti.py
@@ -129,6 +129,7 @@ class LtiConsumer(object):
 
             u'context_id': self.xblock.context_id,
             u'custom_component_display_name': self.xblock.display_name,
+            u'custom_user_id': None,
         }
 
         if self.xblock.due:
@@ -143,7 +144,9 @@ class LtiConsumer(object):
 
         self.xblock.user_email = ""
         self.xblock.user_username = ""
+        self.xblock.user_full_name = ""
         self.xblock.user_language = ""
+        self.xblock.real_user_id = ""
 
         # Username, email, and language can't be sent in studio mode, because the user object is not defined.
         # To test functionality test in LMS
@@ -152,7 +155,10 @@ class LtiConsumer(object):
             real_user_object = self.xblock.runtime.get_real_user(self.xblock.runtime.anonymous_student_id)
             self.xblock.user_email = getattr(real_user_object, "email", "")
             self.xblock.user_username = getattr(real_user_object, "username", "")
+            self.xblock.user_full_name = real_user_object.profile.name
+            names_list = self.xblock.user_full_name.split(' ', 1)
             user_preferences = getattr(real_user_object, "preferences", None)
+            self.xblock.real_user_id = getattr(real_user_object, "id", "")
 
             if user_preferences is not None:
                 language_preference = user_preferences.filter(key='pref-lang')
@@ -163,9 +169,20 @@ class LtiConsumer(object):
             lti_parameters["lis_person_sourcedid"] = self.xblock.user_username
         if self.xblock.ask_to_send_email and self.xblock.user_email:
             lti_parameters["lis_person_contact_email_primary"] = self.xblock.user_email
+        if self.xblock.ask_to_send_first_name and self.xblock.user_full_name:
+            lti_parameters["lis_person_name_given"] = names_list[0]
+        if self.xblock.ask_to_send_last_name and self.xblock.user_full_name:
+            try:
+                lti_parameters["lis_person_name_family"] = names_list[1]
+            except IndexError:
+                lti_parameters["lis_person_name_family"] = ''
+        if self.xblock.ask_to_send_full_name and self.xblock.user_full_name:
+            lti_parameters["lis_person_name_full"] = self.xblock.user_full_name
         if self.xblock.user_language:
             lti_parameters["launch_presentation_locale"] = self.xblock.user_language
 
+        lti_parameters["custom_user_id"] = unicode(self.xblock.real_user_id)
+        
         # Appending custom parameter for signing.
         lti_parameters.update(self.xblock.prefixed_custom_parameters)
 

--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -453,7 +453,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         that contains the link being launched.
         """
         if self.course.is_microsoft_course:
-            return re.sub('\:.*?\+', ':Microsoft+', unicode(self.course_id))
+            return unicode(re.sub('\:.*?\+', ':Microsoft+', self.course_id))
         else:
             return unicode(self.course_id)  # pylint: disable=no-member
 

--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -406,6 +406,13 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     # Users will be presented with a message indicating that their e-mail/username would be sent to a third
     # party application. When "Open in New Page" is not selected, the tool automatically appears without any
     # user action.
+    ask_permission_to_send = Boolean(
+        display_name=_("Enable permission pop-up"),
+        # Translators: This is used to request the user's username for a third party service.
+        help=_("Select True to show pop-up asking user to allow information sharing when launched in new window."),
+        default=True,
+        scope=Scope.settings
+    )
     ask_to_send_username = Boolean(
         display_name=_("Request user's username"),
         # Translators: This is used to request the user's username for a third party service.
@@ -420,12 +427,33 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         default=False,
         scope=Scope.settings
     )
+    ask_to_send_first_name = Boolean(
+        display_name=_("Request user's first name"),
+        # Translators: This is used to request the user's first name for a third party service.
+        help=_("Select True to request the user's first name."),
+        default=False,
+        scope=Scope.settings
+    )
+    ask_to_send_last_name = Boolean(
+        display_name=_("Request user's last name"),
+        # Translators: This is used to request the user's last name for a third party service.
+        help=_("Select True to request the user's last name."),
+        default=False,
+        scope=Scope.settings
+    )
+    ask_to_send_full_name = Boolean(
+        display_name=_("Request user's full name"),
+        # Translators: This is used to request the user's last name for a third party service.
+        help=_("Select True to request the user's full name."),
+        default=False,
+        scope=Scope.settings
+    )
 
     # StudioEditableXBlockMixin configuration of fields editable in Studio
     editable_fields = (
         'display_name', 'description', 'lti_id', 'launch_url', 'custom_parameters', 'launch_target', 'button_text',
         'inline_height', 'modal_height', 'modal_width', 'has_score', 'weight', 'hide_launch', 'accept_grades_past_due',
-        'ask_to_send_username', 'ask_to_send_email'
+        'ask_permission_to_send','ask_to_send_username', 'ask_to_send_email', 'ask_to_send_first_name', 'ask_to_send_last_name', 'ask_to_send_full_name'
     )
 
     def validate_field_data(self, validation, data):
@@ -851,8 +879,12 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'module_score': self.module_score,
             'comment': self.ugettext(sanitized_comment),
             'description': self.description,
+            'ask_permission_to_send': self.ask_permission_to_send,
             'ask_to_send_username': self.ask_to_send_username,
             'ask_to_send_email': self.ask_to_send_email,
+            'ask_to_send_first_name': self.ask_to_send_first_name,
+            'ask_to_send_last_name': self.ask_to_send_last_name,
+            'ask_to_send_full_name': self.ask_to_send_full_name,
             'button_text': self.ugettext(self.button_text),
             'inline_height': self.inline_height,
             'modal_vertical_offset': self._get_modal_position_offset(self.modal_height),

--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -408,7 +408,6 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     # user action.
     ask_permission_to_send = Boolean(
         display_name=_("Enable permission pop-up"),
-        # Translators: This is used to request the user's username for a third party service.
         help=_("Select True to show pop-up asking user to allow information sharing when launched in new window."),
         default=True,
         scope=Scope.settings

--- a/lti_consumer/lti_consumer.py
+++ b/lti_consumer/lti_consumer.py
@@ -452,10 +452,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         context_id is an opaque identifier that uniquely identifies the context (e.g., a course)
         that contains the link being launched.
         """
-        if self.course.is_microsoft_course:
-            return unicode(re.sub('\:.*?\+', ':Microsoft+', self.course_id))
-        else:
-            return unicode(self.course_id)  # pylint: disable=no-member
+        return unicode(self.course_id)  # pylint: disable=no-member
 
     @property
     def role(self):

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -76,6 +76,7 @@ function LtiConsumerXBlock(runtime, element) {
 
         var $element = $(element);
         var $ltiContainer = $element.find('.lti-consumer-container');
+        var askPermissionToSend = $ltiContainer.data('ask-permission-to-send') == 'True';
         var askToSendUsername = $ltiContainer.data('ask-to-send-username') == 'True';
         var askToSendEmail = $ltiContainer.data('ask-to-send-email') == 'True';
 
@@ -88,14 +89,17 @@ function LtiConsumerXBlock(runtime, element) {
 
             // If this instance is configured to require username and/or email, ask user if it is okay to send them
             // Do not launch if it is not okay
-            if(askToSendUsername && askToSendEmail) {
-                launch = confirm(gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
-            } else if (askToSendUsername) {
-                launch = confirm(gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
-            } else if (askToSendEmail) {
-                launch = confirm(gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+            
+            if(askPermissionToSend){
+                if(askToSendUsername && askToSendEmail) {
+                    launch = confirm(gettext("Click OK to have your username and e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+                } else if (askToSendUsername) {
+                    launch = confirm(gettext("Click OK to have your username sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+                } else if (askToSendEmail) {
+                    launch = confirm(gettext("Click OK to have your e-mail address sent to a 3rd party application.\n\nClick Cancel to return to this page without sending your information."));
+                }
             }
-
+            
             if (launch) {
                 window.open($(this).data('target'));
             }

--- a/lti_consumer/templates/html/student.html
+++ b/lti_consumer/templates/html/student.html
@@ -16,6 +16,7 @@
 <div
     id="${element_id}"
     class="${element_class} lti-consumer-container"
+    data-ask-permission-to-send="${ask_permission_to_send}"
     data-ask-to-send-username="${ask_to_send_username}"
     data-ask-to-send-email="${ask_to_send_email}"
 >

--- a/lti_consumer/tests/unit/test_lti.py
+++ b/lti_consumer/tests/unit/test_lti.py
@@ -168,6 +168,9 @@ class TestLtiConsumer(TestLtiConsumerXBlock):
             u'custom_component_graceperiod': str(self.lti_consumer.xblock.graceperiod.total_seconds()),
             'lis_person_sourcedid': 'edx',
             'lis_person_contact_email_primary': 'edx@example.com',
+            'lis_person_name_given': 'First',
+            'lis_person_name_family': 'Last',
+            'lis_person_name_full': 'First Last',
             'launch_presentation_locale': 'en',
             u'custom_param_1': 'custom1',
             u'custom_param_2': 'custom2',
@@ -179,8 +182,12 @@ class TestLtiConsumer(TestLtiConsumerXBlock):
             'oauth_signature': u'fake_signature'
         }
         self.lti_consumer.xblock.has_score = True
+        self.lti_consumer.xblock.ask_permission_to_send = False
         self.lti_consumer.xblock.ask_to_send_username = True
         self.lti_consumer.xblock.ask_to_send_email = True
+        self.lti_consumer.xblock.ask_to_send_first_name = True
+        self.lti_consumer.xblock.ask_to_send_last_name = True
+        self.lti_consumer.xblock.ask_to_send_full_name = True
         self.lti_consumer.xblock.runtime.get_real_user.return_value = Mock(
             email='edx@example.com',
             username='edx',
@@ -193,6 +200,9 @@ class TestLtiConsumer(TestLtiConsumerXBlock):
         self.lti_consumer.xblock.runtime.get_real_user.return_value = {}
         del expected_lti_parameters['lis_person_sourcedid']
         del expected_lti_parameters['lis_person_contact_email_primary']
+        del expected_lti_parameters['lis_person_name_given']
+        del expected_lti_parameters['lis_person_name_family']
+        del expected_lti_parameters['lis_person_name_full']
         del expected_lti_parameters['launch_presentation_locale']
         self.assertEqual(self.lti_consumer.get_signed_lti_parameters(), expected_lti_parameters)
 

--- a/lti_consumer/tests/unit/test_lti_consumer.py
+++ b/lti_consumer/tests/unit/test_lti_consumer.py
@@ -722,8 +722,8 @@ class TestGetContext(TestLtiConsumerXBlock):
         """
         context_keys = (
             'launch_url', 'element_id', 'element_class', 'launch_target', 'display_name', 'form_url', 'hide_launch',
-            'has_score', 'weight', 'module_score', 'comment', 'description', 'ask_to_send_username',
-            'ask_to_send_email', 'button_text', 'modal_vertical_offset', 'modal_horizontal_offset', 'modal_width',
+            'has_score', 'weight', 'module_score', 'comment', 'description', 'ask_permission_to_send', 'ask_to_send_username',
+            'ask_to_send_email', 'ask_to_send_first_name', 'ask_to_send_last_name', 'ask_to_send_full_name', 'button_text', 'modal_vertical_offset', 'modal_horizontal_offset', 'modal_width',
             'accept_grades_past_due'
         )
         context = self.xblock._get_context_for_template()  # pylint: disable=protected-access

--- a/lti_consumer/utils.py
+++ b/lti_consumer/utils.py
@@ -9,3 +9,39 @@ def _(text):
     :return text
     """
     return text
+
+
+def get_cohort(course_key, user):
+    try:
+        from openedx.core.djangoapps.course_groups import cohorts
+        from opaque_keys.edx.keys import CourseKey
+    except ImportError:
+        return None, None
+
+    cohort = cohorts.get_cohort(course_key=CourseKey.from_string(course_key), user=user)
+    if cohort.name:
+        return unicode(cohort.pk), cohort.name
+    else:
+        return None, None
+
+
+def get_team(course_key, user):
+    from django.conf import settings
+    features = getattr(settings, 'FEATURES', {})
+
+    if not features.get('ENABLE_TEAMS'):
+        return None, None
+
+    # No need for handling ImportError, since `ENABLE_TEAMS` is set to True.
+    from lms.djangoapps.teams.models import CourseTeamMembership
+    from opaque_keys.edx.keys import CourseKey
+
+    try:
+        membership = CourseTeamMembership.objects.get(
+            user=user,
+            team__course_id=CourseKey.from_string(course_key),
+        )
+    except CourseTeamMembership.DoesNotExist:
+        return None, None
+
+    return unicode(membership.team.team_id), membership.team.name


### PR DESCRIPTION
### Before Reviewing

 - Please take a look at this document: [Integration Scenarios for Riff Learning](https://docs.google.com/document/d/1roF4NrrU9bcEePBL4wz49clVozH76_vnrLkh4SsGpAY/edit#)

### Overview
This is a stop-gap solution until we can find a more proper one and push it upstream. The work to push this upstream is ongoing and it's highly likely to have the exact same interface as far as Riff's LTI provider is concerned.

 - **Upstream Pull Request:** [Allow plugins for the LTI XBlock to pass extra parameters to the provider - edx#43](https://github.com/edx/xblock-lti-consumer/pull/43)

### TODO
 - [x] Add the `team_id` and `cohort_id`
 - [x] ~Add `custom_` before the other custom parameters~ reverted.

### Challenges
 - [ ] Although the provider might not be affected, the Studio UX could be changed. We let Riff Learning know about the possible changes.

### Unrelated Changes
I'd like to undo the the Microsoft hacks. I think it's completely necessary for Tahoe. Right?